### PR TITLE
Fix code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/parse/lexer.go
+++ b/parse/lexer.go
@@ -236,6 +236,9 @@ func (sc *Scanner) scanEscape(ch int, buf *bytes.Buffer) error {
 				bytes = append(bytes, byte(sc.Next()))
 			}
 			val, _ := strconv.ParseInt(string(bytes), 10, 32)
+			if val < 0 || val > 255 {
+				return fmt.Errorf("escape sequence out of range: %d", val)
+			}
 			writeChar(buf, int(val))
 		} else {
 			writeChar(buf, ch)


### PR DESCRIPTION
Fixes [https://github.com/zmsvDreamLang/Milk/security/code-scanning/3](https://github.com/zmsvDreamLang/Milk/security/code-scanning/3)

To fix the problem, we need to ensure that the value parsed by `strconv.ParseInt` is within the range of a byte (0 to 255) before converting it. This can be done by adding a bounds check after parsing the integer and before writing it to the buffer. If the value is out of range, we can handle it appropriately, such as by returning an error or using a default value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
