### PR TITLE
Fix code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/state.go
+++ b/state.go
@@ -1662,6 +1662,9 @@ func (ls *LState) ToInt(n int) int {
 	}
 	if lv, ok := ls.Get(n).(LString); ok {
 		if num, err := parseNumber(string(lv)); err == nil {
+			if num > math.MaxInt || num < math.MinInt {
+			    return 0 // or handle the error appropriately
+			}
 			return int(num)
 		}
 	}


### PR DESCRIPTION
Fixes [https://github.com/zmsvDreamLang/Milk/security/code-scanning/4](https://github.com/zmsvDreamLang/Milk/security/code-scanning/4)

To fix the problem, we need to ensure that the parsed number from `parseNumber` fits within the bounds of an `int` before converting it. This can be done by adding a bounds check in the `ToInt` function. If the parsed number exceeds the maximum or minimum value of an `int`, we should handle it appropriately, such as returning a default value or an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
